### PR TITLE
Pull nathan j phillips #10

### DIFF
--- a/Bifrost.Devices.Gpio.Abstractions/IGpioController.cs
+++ b/Bifrost.Devices.Gpio.Abstractions/IGpioController.cs
@@ -8,6 +8,6 @@ namespace Bifrost.Devices.Gpio.Abstractions
 
         void ClosePin(int pinNumber);
 
-        IDictionary<string, string> Pins { get; }
+        IDictionary<int, IGpioPin> Pins { get; }
     }
 }

--- a/Bifrost.Devices.Gpio.Abstractions/IGpioController.cs
+++ b/Bifrost.Devices.Gpio.Abstractions/IGpioController.cs
@@ -4,10 +4,6 @@ namespace Bifrost.Devices.Gpio.Abstractions
 {
     public interface IGpioController
     {
-        IGpioPin OpenPin(int pinNumber);
-
-        void ClosePin(int pinNumber);
-
         IDictionary<int, GetGpioPinDelegate> Pins { get; }
     }
 

--- a/Bifrost.Devices.Gpio.Abstractions/IGpioController.cs
+++ b/Bifrost.Devices.Gpio.Abstractions/IGpioController.cs
@@ -8,6 +8,8 @@ namespace Bifrost.Devices.Gpio.Abstractions
 
         void ClosePin(int pinNumber);
 
-        IDictionary<int, IGpioPin> Pins { get; }
+        IDictionary<int, GetGpioPinDelegate> Pins { get; }
     }
+
+    public delegate IGpioPin GetGpioPinDelegate();
 }

--- a/Bifrost.Devices.Gpio.Abstractions/IGpioPin.cs
+++ b/Bifrost.Devices.Gpio.Abstractions/IGpioPin.cs
@@ -10,5 +10,7 @@ namespace Bifrost.Devices.Gpio.Abstractions
         GpioPinValue Read();
 
         void SetDriveMode(GpioPinDriveMode driveMode);
+
+        void Close(int pinNumber);
     }
 }

--- a/Bifrost.Devices.Gpio.Abstractions/IGpioPin.cs
+++ b/Bifrost.Devices.Gpio.Abstractions/IGpioPin.cs
@@ -10,7 +10,5 @@ namespace Bifrost.Devices.Gpio.Abstractions
         GpioPinValue Read();
 
         void SetDriveMode(GpioPinDriveMode driveMode);
-
-        void Close(int pinNumber);
     }
 }

--- a/Bifrost.Devices.Gpio/GpioController.cs
+++ b/Bifrost.Devices.Gpio/GpioController.cs
@@ -74,48 +74,8 @@ namespace Bifrost.Devices.Gpio
         private GetGpioPinDelegate GetGpioPin(Tuple<DirectoryInfo, int?> diAndPinNo)
         {
             return () => {
-                return new GpioPin(diAndPinNo.Item2.Value, diAndPinNo.Item1.FullName);
+                return new GpioPin(diAndPinNo.Item2.Value, diAndPinNo.Item1.FullName, DevicePath);
             };
-        }
-
-        public IGpioPin OpenPin(int pinNumber)
-        {
-            if (pinNumber < 1 || pinNumber > 26)
-            {
-                throw new ArgumentOutOfRangeException("Valid pins are between 1 and 26.");
-            }
-            // add a file to the export directory with the name <<pin number>>
-            // add folder under device path for "gpio<<pinNumber>>"
-            var gpioDirectoryPath = Path.Combine(DevicePath, string.Concat("gpio", pinNumber.ToString()));
-
-            var gpioExportPath = Path.Combine(DevicePath, "export");
-            
-            if (!Directory.Exists(gpioDirectoryPath))
-            {
-                File.WriteAllText(gpioExportPath, pinNumber.ToString());
-                Directory.CreateDirectory(gpioDirectoryPath);
-            }
-
-            // instantiate the gpiopin object to return with the pin number.
-            return new GpioPin(pinNumber, gpioDirectoryPath);
-        }
-
-        public void ClosePin(int pinNumber)
-        {
-            if (pinNumber < 1 || pinNumber > 26)
-            {
-                throw new ArgumentOutOfRangeException("Valid pins are between 1 and 26.");
-            }
-            // add a file to the export directory with the name <<pin number>>
-            // add folder under device path for "gpio<<pinNumber>>"
-            var gpioDirectoryPath = Path.Combine(DevicePath, string.Concat("gpio", pinNumber.ToString()));
-
-            var gpioExportPath = Path.Combine(DevicePath, "unexport");
-
-            if (Directory.Exists(gpioDirectoryPath))
-            {
-                File.WriteAllText(gpioExportPath, pinNumber.ToString());
-            }
         }
     }
 }

--- a/Bifrost.Devices.Gpio/GpioController.cs
+++ b/Bifrost.Devices.Gpio/GpioController.cs
@@ -58,26 +58,15 @@ namespace Bifrost.Devices.Gpio
             }
         }
         
-        public IDictionary<string, string> Pins
+        public IDictionary<int, IGpioPin> Pins
         {
             get
             {
-                DirectoryInfo gpioPins = new DirectoryInfo(DevicePath);
-
-                IDictionary<string, string> pinNameValues = new Dictionary<string, string>();
-
-                var pinNames = gpioPins.GetDirectories()
-                    .Where(m => m.Name.StartsWith("gpio"))
-                    .Where(m => !m.Name.StartsWith("gpiochip"))
-                    .Select(m => m.Name)
-                    .ToArray();
-
-                foreach (var pinName in pinNames)
-                {
-                    pinNameValues.Add(pinName, File.ReadAllText(Path.Combine(DevicePath, pinName, "value")));
-                }
-
-                return pinNameValues;
+                return new DirectoryInfo(DevicePath).GetDirectories()
+                    .Where(di => di.Name.StartsWith("gpio"))
+                    .Select(di => Tuple.Create(di, int.TryParse(di.Name.Substring("gpio".Length), out int value) ? value : (int?)null))
+                    .Where(diAndPinNo => diAndPinNo.Item2.HasValue)
+                    .ToDictionary(diAndPinNo => diAndPinNo.Item2.Value, diAndPinNo => (IGpioPin)new GpioPin(diAndPinNo.Item2.Value, diAndPinNo.Item1.FullName));
             }
         }
 

--- a/Bifrost.Devices.Gpio/GpioController.cs
+++ b/Bifrost.Devices.Gpio/GpioController.cs
@@ -57,8 +57,9 @@ namespace Bifrost.Devices.Gpio
                 return instance;
             }
         }
-        
-        public IDictionary<int, IGpioPin> Pins
+
+
+        public IDictionary<int, GetGpioPinDelegate> Pins
         {
             get
             {
@@ -66,8 +67,15 @@ namespace Bifrost.Devices.Gpio
                     .Where(di => di.Name.StartsWith("gpio"))
                     .Select(di => Tuple.Create(di, int.TryParse(di.Name.Substring("gpio".Length), out int value) ? value : (int?)null))
                     .Where(diAndPinNo => diAndPinNo.Item2.HasValue)
-                    .ToDictionary(diAndPinNo => diAndPinNo.Item2.Value, diAndPinNo => (IGpioPin)new GpioPin(diAndPinNo.Item2.Value, diAndPinNo.Item1.FullName));
+                    .ToDictionary(diAndPinNo => diAndPinNo.Item2.Value, diAndPinNo => GetGpioPin(diAndPinNo) );
             }
+        }
+
+        private GetGpioPinDelegate GetGpioPin(Tuple<DirectoryInfo, int?> diAndPinNo)
+        {
+            return () => {
+                return new GpioPin(diAndPinNo.Item2.Value, diAndPinNo.Item1.FullName);
+            };
         }
 
         public IGpioPin OpenPin(int pinNumber)


### PR DESCRIPTION
Changed this so it's using a Delegate method to prevent all GPIO pins being initialised at application startup any only initialize them when they are obtained 

Should be used 

`GpioPin gpiop0 = (GpioPin) GpioController.Instance.Pins[0]();`